### PR TITLE
ListBox: Fix:  'row_height' gets ignored in PySide2 15.5.2

### DIFF
--- a/python/vfxui/listbox.py
+++ b/python/vfxui/listbox.py
@@ -577,7 +577,7 @@ class ListBox(QtWidgets.QWidget):
                               index=self.count(),
                               **self._kwargs)
         item.visible = True
-        size_hint = QtCore.QSize(-1, self.row_height)
+        size_hint = QtCore.QSize(0, self.row_height)
         item.setSizeHint(size_hint)
 
         self.list.addItem(item)


### PR DESCRIPTION
# Details

### Repro:
```python
from vfxui.dialog import Dialog, createDialog

class MyDialog(Dialog):
    def initialize(self, **kwargs):
        self.content = ['Foo', 'Bar', 'Baz']

    def defineLayout(self, **kwargs):
       self.addListBox(content=self.content,
                       row_height=50)

d = createDialog(targetclass=MyDialog)
d.showModal()
```

### Expected Result:
![expected](https://user-images.githubusercontent.com/994547/175897428-f711468c-79dc-4e45-a4d6-dca35ead91f6.png)
→ Works as expected in `Python 2.7.x (PySide)` and `Python 3.7.x (PySide2 15.2.2)`
### Faulty Result in `PySide2` version `15.5.2`:
_(→ e.g. in Maya 2022)_
![faulty](https://user-images.githubusercontent.com/994547/175897701-6a83b92e-f77d-4474-8690-98b27de9758d.png)

<br/>

### Cause

- List Rows get added via `QListWidget.addItem()` calls.
- For controlling the `row_height` we create a `QSize()` object and call `setSizeHint()`:
   ```python
    size_hint = QtCore.QSize(-1, self.row_height)
    item.setSizeHint(size_hint)
    ```
- We are setting **width** to `-1` for this `QSize`, as we only want to control/specify the **height**.
- However this results in this `QSize` object **not being valid anymore**:
   ```python
   size_hint = QtCore.QSize(-1, self.row_height)
   print(size_hint.isValid())
   ```

- Apparently older versions of PySide and PySide2 gracefully ignore the illegal state of the `QSize` object, but `15.5.2` is only processing legal `QSize` objects.

### Solution

- Set **width** to `0` instead:
 ```python
 size_hint = QtCore.QSize(0, self.row_height)
 ```

→ This results in a **valid `QSize` object** and behaves as expected in all tested versions of `PySide` and `PySide2`.
